### PR TITLE
Adds multistage, start.sh and updates README

### DIFF
--- a/novosga-2.0/Dockerfile
+++ b/novosga-2.0/Dockerfile
@@ -1,39 +1,52 @@
+#Build stage, useful for a better use of cache ;)
+FROM composer:1.5.2 AS build
+
+ENV NOVOSGA_VER=v2.0.0-BETA3 \
+    NOVOSGA_MD5=d8d05e4cb386570f18b33339207529fa
+
+ENV NOVOSGA_FILE=novosga.tar.gz \
+    NOVOSGA_DIR=/var/www/html \
+    APP_ENV=prod \
+    NOVOSGA_URL=https://github.com/novosga/novosga/archive/${NOVOSGA_VER}.tar.gz \
+    DATABASE_PASS=123456 \
+    DATABASE_URL=mysql://root@127.0.0.1:3306/novosga?charset=utf8mb4&serverVersion=5.7
+
+RUN set -xe \
+    && mkdir -p $NOVOSGA_DIR && cd $NOVOSGA_DIR \
+    && docker-php-ext-install pcntl \
+    && curl -fSL ${NOVOSGA_URL} -o ${NOVOSGA_FILE} \
+    && echo "${NOVOSGA_MD5}  ${NOVOSGA_FILE}" | md5sum -c \
+    && tar -xz --strip-components=1 -f ${NOVOSGA_FILE} \
+    && rm ${NOVOSGA_FILE} \
+    && composer install --no-dev
+
 FROM php:7.1-apache
 
-ENV NOVOSGA_VER v2.0.0-BETA3
-ENV NOVOSGA_MD5 d8d05e4cb386570f18b33339207529fa
-ENV NOVOSGA_URL https://github.com/novosga/novosga/archive/${NOVOSGA_VER}.tar.gz
-ENV NOVOSGA_FILE novosga.tar.gz
-ENV NOVOSGA_DIR /var/www/novosga
-
-ARG APP_ENV=prod
-ARG DATABASE_PASS=123456
-ARG DATABASE_URL=mysql://root@127.0.0.1:3306/novosga?charset=utf8mb4&serverVersion=5.7
-
-RUN apt-get update \
+RUN set -xe \
+    && apt-get update \
     && apt-get install -y \
         libicu-dev \
         libxml2-dev \
         zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && docker-php-ext-install \
+        intl \
+        pcntl \
+        pdo \
+        pdo_mysql \
+        xml \
+        zip \
+    && apt-get remove -y --purge \
+        postgresql-server-dev-all \
+        libicu-dev \
+        libxml2-dev \
+        zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && a2enmod rewrite env \
+    && echo 'session.save_path = "/tmp"' > /usr/local/etc/php/conf.d/sessionsavepath.ini \
+    && echo 'date.timezone = ${TZ}' > /usr/local/etc/php/conf.d/datetimezone.ini
 
-RUN docker-php-ext-install \
-  intl \
-  pcntl \
-  pdo \
-  pdo_mysql \
-  xml \
-  zip
-
-RUN set -xe \
-    && curl -fSL ${NOVOSGA_URL} -o ${NOVOSGA_FILE} \
-    && echo "${NOVOSGA_MD5}  ${NOVOSGA_FILE}" | md5sum -c \
-    && tar -xz --strip-components=1 -f ${NOVOSGA_FILE} \
-    && rm ${NOVOSGA_FILE}
-
-RUN set -xe \
-    && curl -fSL https://getcomposer.org/composer.phar -o composer.phar \
-    && php composer.phar install --no-dev
+COPY --from=build /var/www/html /var/www/html
 
 RUN set -xe \
     && chown -R www-data:www-data . \
@@ -47,4 +60,20 @@ PassEnv APP_ENV\n\
 PassEnv DATABASE_URL\n\
 PassEnv DATABASE_PASS' > public/.htaccess
 
-RUN a2enmod rewrite env
+#Set the default parameters
+ENV APP_ENV=prod \
+    NOVOSGA_ADMIN_USERNAME="admin" \
+    NOVOSGA_ADMIN_PASSWORD="123456" \
+    NOVOSGA_ADMIN_FIRSTNAME="Administrator" \
+    NOVOSGA_ADMIN_LASTNAME="Global" \
+    NOVOSGA_UNITY_NAME="My Unity" \
+    NOVOSGA_UNITY_CODE="U01" \
+    NOVOSGA_NOPRIORITY_NAME="Normal" \
+    NOVOSGA_NOPRIORITY_DESCRIPTION="Normal service" \
+    NOVOSGA_PRIORITY_NAME="Priority" \
+    NOVOSGA_PRIORITY_DESCRIPTION="Priority service" \
+    NOVOSGA_PLACE_NAME="Box"
+
+    COPY start.sh /usr/local/bin
+
+    CMD ["start.sh"]

--- a/novosga-2.0/README.md
+++ b/novosga-2.0/README.md
@@ -1,6 +1,46 @@
 # NovoSGA 2.0
 
-Compose file
+## Docker image milestones
+[x] Pre-flight check  
+[x] Auto setup  
+[ ] docker secrets support
+
+## How to use
+
+The container will check if the required settings are set and will start the database setup automatically.  
+You can set the system as you like with environment variables (using docker-compose.yml or `-e` flags at `docker container run`)
+
+### Settings (environment variables)
+
+| Option                         | Default setting   | Description                      | Optional? |
+| ------------------------------ | ----------------- | -------------------------------- | :-------: |
+| APP_ENV                        | prod              | Environment running the app      | yes       |
+| DATABASE_URL                   | *blank*             | Database connection string       | ***no***      |
+| DATABASE_PASS                  | *blank*             | Database password                | ***no***      |
+| NOVOSGA_ADMIN_USERNAME         | admin             | Admin username                   | yes       |
+| NOVOSGA_ADMIN_PASSWORD         | 123456            | Admin password                   | yes       |
+| NOVOSGA_ADMIN_FIRSTNAME        | Administrator     | Administrator first name         | yes       |
+| NOVOSGA_ADMIN_LASTNAME         | Global            | Administrador last name          | yes       |
+| NOVOSGA_UNITY_NAME             | My Unity          | Unity name                       | yes       |
+| NOVOSGA_UNITY_CODE             | U01               | Unity code                       | yes       |
+| NOVOSGA_NOPRIORITY_DESCRIPTION | Normal service    | Non-Priority service description | yes       |
+| NOVOSGA_PRIORITY_NAME          | Priority          | Priority service name            | yes       |
+| NOVOSGA_PRIORITY_DESCRIPTION   | Priority service  | Priority service description     | yes       |
+| NOVOSGA_PLACE_NAME             | Box               | Place name                       | yes       |
+| TZ                             | UTC               | Timezone                         | yes       |
+
+### CLI
+
+Minimal setting:
+
+```shell
+ docker container run [--rm|-d] \
+  -e DATABASE_URL="connection_string" \
+  -e DATABASE_PASS="database_password" \
+  novosga/novosga:latest
+```
+
+### Compose file
 
 ```yaml
 version: '2'
@@ -34,6 +74,8 @@ services:
       NOVOSGA_PRIORITY_DESCRIPTION: 'Priority service'
       # default place
       NOVOSGA_PLACE_NAME: 'Box'
+      # Set TimeZone
+      TZ: 'America/Sao_Paulo'
   mysqldb:
     image: mysql:5.7
     restart: always
@@ -41,29 +83,5 @@ services:
       MYSQL_USER: 'novosga'
       MYSQL_DATABASE: 'novosga2'
       MYSQL_ROOT_PASSWORD: 'MySQL_r00t_P@ssW0rd!'
-```
-
-Running docker-compose
-
-```
-docker-compose up -d
-```
-
-Log in on MySQL database as root:
-
-```
-docker-compose exec mysqldb sh -c  'mysql -uroot -p'
-```
-
-Grant access to application user:
-
-```sql
-GRANT ALL ON novosga2.* TO 'novosga'@'%' IDENTIFIED BY 'MySQL_App_P@ssW0rd!';
-quit
-```
-
-Run Novo SGA install
-
-```
-docker-compose exec novosga sh -c 'bin/console novosga:install'
+      MYSQL_PASSWORD: 'MySQL_App_P@ssW0rd!'
 ```

--- a/novosga-2.0/start.sh
+++ b/novosga-2.0/start.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+echo "Starting pre-flight check..."
+
+echo -n "Database url: "
+if [ -z "$DATABASE_URL" ]; then
+    echo "\nYou need to tell me where the database is and how to connect to it by setting DATABASE_URL environment variable"
+    echo "e.g.: Using the flag -e DATABASE_URL='mysql://root@127.0.0.1:3306/novosga?charset=utf8mb4&serverVersion=5.7' at docker container run"
+    exit 1
+fi
+echo "Ok"
+
+echo -n "Database password: "
+if [ -z "$DATABASE_PASS" ]; then
+    echo "\nYou need to tell me the database password by setting DATABASE_PASS environment variable"
+    echo "e.g.: Using the flag -e DATABASE_PASS='password' at docker container run"
+    exit 1
+fi
+echo "Ok"
+
+# we need to wait until the database is up and accepting connections
+until bin/console -q doctrine:query:sql "select version()" > /dev/null 2>&1; do 
+    echo "Waiting for database..."; 
+    sleep 5; 
+done
+
+echo "Database is up, configuring schema"
+
+set -xe
+
+#Install/Updates the database schema
+/var/www/html/bin/console novosga:install
+
+#Ensures all files have the right owner
+chown -R www-data:www-data /var/www/html/*
+
+echo "Setup done! Starting apache"
+exec apache2-foreground


### PR DESCRIPTION
Now the image will be built with a multistage build, which improves
cache use, the order of the Dockerfile was changed to improve cache use
as well, some minor changes were made to shrink the image size.

A init script (start.sh) was added as well, it performs a pre-flight
check, set/update the database (i was lucky that the `console
novosga:install` script is idempotent) and then starts apache (which
makes the life of the user easier)

README.md was updated with all the (minimal) instructions needed to use the image