### PR TITLE
fix: novosga v2.3 frankenphp

### DIFF
--- a/novosga-2.3-standalone/Dockerfile
+++ b/novosga-2.3-standalone/Dockerfile
@@ -17,6 +17,8 @@ ENV APP_ENV=prod \
 
 USER root
 
+RUN apk add --no-cache supervisor
+
 # https://github.com/aptible/supercronic/releases/tag/v0.2.33
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.33/supercronic-linux-amd64 \
     SUPERCRONIC_SHA1SUM=71b0d58cc53f6bd72cf2f293e09e294b79c666d8 \
@@ -30,7 +32,7 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 
 COPY start.sh /usr/local/bin
 COPY consumer.sh /usr/local/bin
-COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY config/supervisord.conf /etc/supervisord.conf
 COPY config/crontab /etc/crontab
 
 USER nobody

--- a/novosga-2.3-standalone/config/crontab
+++ b/novosga-2.3-standalone/config/crontab
@@ -1,3 +1,3 @@
 # m h  dom mon dow   command
-0 1 * * * /var/www/html/bin/console novosga:reset
-*/15 * * * * /var/www/html/bin/console novosga:scheduling:sync
+0 1 * * * /app/bin/console novosga:reset
+*/15 * * * * /app/bin/console novosga:scheduling:sync

--- a/novosga-2.3-standalone/config/supervisord.conf
+++ b/novosga-2.3-standalone/config/supervisord.conf
@@ -2,19 +2,10 @@
 nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
-pidfile=/run/supervisord.pid
+pidfile=/tmp/supervisord.pid
 
-[program:php-fpm]
-command=php-fpm82 -F
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=false
-startretries=0
-
-[program:nginx]
-command=nginx -g 'daemon off;'
+[program:frankenphp]
+command=frankenphp run --config /etc/frankenphp/Caddyfile --adapter caddyfile
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/novosga-2.3-standalone/start.sh
+++ b/novosga-2.3-standalone/start.sh
@@ -26,4 +26,4 @@ set -xe
 bin/console novosga:install
 
 echo "Setup done! Starting application"
-exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
This pull request updates the Docker setup for the `novosga-2.3-standalone` environment, focusing on switching from `php-fpm` and `nginx` to `frankenphp`, refining the use of `supervisor`, and updating paths for better container compatibility. The most important changes are grouped below.

**Container orchestration and process management:**

* Added installation of `supervisor` via `apk` to ensure it's available in the container.
* Changed the location of the `supervisord.conf` file to `/etc/supervisord.conf` and updated references accordingly. [[1]](diffhunk://#diff-0a9cf86d8156efb5165d24a9966cf0faa891c2033a6bb8e008d239d1e1a5dbc5L33-R35) [[2]](diffhunk://#diff-b353dd2033b96b70704b92b71da64e67b5b3cfd4381163afb030ed32eb55b70fL29-R29)

**Web server and PHP process:**

* Replaced separate `php-fpm` and `nginx` supervisor programs with a single `frankenphp` process managed by supervisor, using the Caddyfile configuration.

**Configuration and paths:**

* Updated crontab commands to use `/app/bin/console` instead of `/var/www/html/bin/console` for better alignment with the container's directory structure.
* Changed the supervisor PID file location from `/run/supervisord.pid` to `/tmp/supervisord.pid` to avoid permission issues in some container environments.